### PR TITLE
updating sharp to 0.28.3 to support arm64 (M1) architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "sharp": "0.27.1",
+    "sharp": "0.28.3",
     "plugin-error": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #3

This package throws an error when attempting to install on an M1 processor. Upgrading to the latest version of `sharp` resolves this.

More info [in the sharp documentation](https://sharp.pixelplumbing.com/install#apple-m1).