### PR TITLE
fix: update sharp to latest version (to patch security issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "dependencies": {
     "plugin-error": "1.0.1",
-    "sharp": "^0.31.1"
+    "sharp": "^0.32.6"
   },
   "devDependencies": {
     "ava": "^5.0.1",


### PR DESCRIPTION
It seems the sharp version used at the moment is vulnerable because of a libwebp dependency.

Learned about the issue through [_sharp vulnerability in libwebp dependency CVE-2023-4863_](https://github.com/j9t/imagemin-guard/security/dependabot/16) (as it impacts one of my projects), which in turn points to [_libwebp: OOB write in BuildHuffmanTable_](https://github.com/advisories/GHSA-j7hp-h8jx-5ppr) for more details.